### PR TITLE
[AI-82] 채팅방 조회 구현

### DIFF
--- a/src/main/java/com/example/chat/dto/ChatMessage.java
+++ b/src/main/java/com/example/chat/dto/ChatMessage.java
@@ -1,0 +1,29 @@
+package com.example.chat.dto;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.io.Serializable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+public class ChatMessage implements Serializable {
+
+  private static final long serialVersionUID = 6494678977089006639L;
+  @NotEmpty
+  @Size(max = 100, message = "메시지 글자 수는 최대 100자입니다.")
+  private String message;
+
+  @JsonCreator
+  private ChatMessage(String message) {
+    this.message = message;
+  }
+
+  public static ChatMessage from(String message) {
+    return new ChatMessage(message);
+  }
+}

--- a/src/main/java/com/example/chat/exception/ErrorMessage.java
+++ b/src/main/java/com/example/chat/exception/ErrorMessage.java
@@ -1,0 +1,12 @@
+package com.example.chat.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum ErrorMessage {
+  NONEXISTENT_TOPIC("존재하지 않는 topic입니다.");
+  private final String message;
+}

--- a/src/main/java/com/example/chat/service/RedisSubscriber.java
+++ b/src/main/java/com/example/chat/service/RedisSubscriber.java
@@ -1,0 +1,38 @@
+package com.example.chat.service;
+
+import com.example.chat.dto.ChatMessage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RedisSubscriber implements MessageListener {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final ObjectMapper objectMapper;
+
+  private final SimpMessageSendingOperations simpMessageSendingOperations;
+
+  @Override
+  public void onMessage(Message message, byte[] pattern) {
+    String id = redisTemplate.getStringSerializer().deserialize(message.getChannel());
+    String messageBody = redisTemplate.getStringSerializer()
+                                      .deserialize(message.getBody());
+    ChatMessage chatMessage = null;
+    try {
+      chatMessage = objectMapper.readValue(messageBody, ChatMessage.class);
+    } catch (JsonProcessingException e) {
+      log.info(e.getMessage());
+      return;
+    }
+    simpMessageSendingOperations.convertAndSend("/topic/" + id, chatMessage);
+  }
+}

--- a/src/main/java/com/example/chat/service/TopicService.java
+++ b/src/main/java/com/example/chat/service/TopicService.java
@@ -1,6 +1,10 @@
 package com.example.chat.service;
 
+import com.example.entity.Topic;
+
 public interface TopicService {
 
   void create(String id);
+
+  Topic findById(String id);
 }

--- a/src/main/java/com/example/chat/service/TopicServiceImpl.java
+++ b/src/main/java/com/example/chat/service/TopicServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.chat.service;
 
+import static com.example.chat.exception.ErrorMessage.NONEXISTENT_TOPIC;
+
 import com.example.chat.repository.TopicRepository;
 import com.example.entity.Topic;
 import lombok.RequiredArgsConstructor;
@@ -22,5 +24,11 @@ public class TopicServiceImpl implements TopicService {
     redisMessageListenerContainer.addMessageListener(redisSubscriber,
       new org.springframework.data.redis.listener.ChannelTopic(id));
     topicRepository.save(Topic.from(id));
+  }
+
+  @Override
+  public Topic findById(String id) {
+    return topicRepository.findById(id).orElseThrow(
+      () -> new IllegalArgumentException(NONEXISTENT_TOPIC.getMessage()));
   }
 }

--- a/src/main/java/com/example/entity/Topic.java
+++ b/src/main/java/com/example/entity/Topic.java
@@ -1,0 +1,20 @@
+package com.example.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@RedisHash
+public class Topic {
+
+  @Id
+  private final String id;
+
+  public static Topic from(String id) {
+    return new Topic(id);
+  }
+}

--- a/src/test/java/com/example/chat/service/TopicServiceImplTest.java
+++ b/src/test/java/com/example/chat/service/TopicServiceImplTest.java
@@ -1,12 +1,16 @@
 package com.example.chat.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 
 import com.example.chat.repository.TopicRepository;
 import com.example.entity.Topic;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -59,6 +63,49 @@ class TopicServiceImplTest {
         verify(redisMessageListenerContainer).addMessageListener(any(MessageListener.class), any(
           ChannelTopic.class));
         verify(topicRepository).save(any(Topic.class));
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("findById 메서드는")
+  class DescribeFindById {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("토픽을 찾아서 반환한다")
+      void ItReturnsTopic() {
+        // given
+        String id = "topic1";
+        given(topicRepository.findById(anyString()))
+          .willReturn(Optional.of(Topic.from(id)));
+
+        // when
+        Topic topic = topicService.findById(id);
+
+        // then
+        assertThat(topic.getId()).isEqualTo(id);
+      }
+    }
+
+    @Nested
+    @DisplayName("존재하지 않는 아이디라면")
+    class ContextWithNonexistentId {
+
+      @Test
+      @DisplayName("IllegalArgumentException을 던진다")
+      void ItThrowsIllegalArgumentException() {
+        // given
+        String id = "topic1";
+        given(topicRepository.findById(anyString()))
+          .willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> topicService.findById(id)).isInstanceOf(
+          IllegalArgumentException.class);
       }
     }
   }


### PR DESCRIPTION
* 메시지 전송 요청이 왔을때 해당 채팅방이 있는지 확인하기 위해 사용할 service, repository를 구현하였습니다.
* 이전 커밋에서 빠트린 Topic 클래스도 추가하였습니다. 죄송합니다!

클래스 역할 설명
* SimpMessageSendingOperations 을 통해 실제 사용자에게 메시지를 전달
* Redis Publisher에서 메시지를 발행하면 Redis Subscriber에서 메시지를 받게됨
* Topic은 채팅방 채널을 나타냄