### PR TITLE
[AI-84] 채팅 메시지 전송

### DIFF
--- a/backend/chat/build.gradle
+++ b/backend/chat/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+    testImplementation 'it.ozimov:embedded-redis:0.7.2'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/backend/chat/src/main/java/com/example/controller/ChatController.java
+++ b/backend/chat/src/main/java/com/example/controller/ChatController.java
@@ -1,0 +1,31 @@
+package com.example.controller;
+
+import com.example.dto.ChatMessage;
+import com.example.service.ChatService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class ChatController {
+
+  private final ChatService chatService;
+
+
+  @MessageMapping("/{id}/send")
+  public void send(@DestinationVariable @NotEmpty String id, @Valid ChatMessage message) {
+    chatService.send(id, message);
+  }
+
+  @MessageExceptionHandler({Exception.class})
+  public void handleException(Exception e) {
+    log.info(e.getMessage());
+  }
+}

--- a/backend/chat/src/main/java/com/example/domain/Topic.java
+++ b/backend/chat/src/main/java/com/example/domain/Topic.java
@@ -1,20 +1,26 @@
 package com.example.domain;
 
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 @RedisHash
 public class Topic {
 
   @Id
   private final String id;
 
-  public static Topic from(String id) {
-    return new Topic(id);
+  private final LocalDateTime expireAt;
+
+  public static Topic from(String id, LocalDateTime expireAt) {
+    return Topic.builder()
+                .id(id)
+                .expireAt(expireAt)
+                .build();
   }
 }

--- a/backend/chat/src/main/java/com/example/dto/ChatMessage.java
+++ b/backend/chat/src/main/java/com/example/dto/ChatMessage.java
@@ -2,10 +2,10 @@ package com.example.dto;
 
 import static lombok.AccessLevel.PRIVATE;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import java.io.Serializable;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,16 +14,25 @@ import lombok.NoArgsConstructor;
 public class ChatMessage implements Serializable {
 
   private static final long serialVersionUID = 6494678977089006639L;
+
+  @NotEmpty
+  @Size(max = 255, message = "닉네임 길이는 최대 255자입니다.")
+  private String sender;
+
   @NotEmpty
   @Size(max = 100, message = "메시지 글자 수는 최대 100자입니다.")
-  private String message;
+  private String content;
 
-  @JsonCreator
-  private ChatMessage(String message) {
-    this.message = message;
+  @Builder(access = PRIVATE)
+  private ChatMessage(String sender, String content) {
+    this.sender = sender;
+    this.content = content;
   }
 
-  public static ChatMessage from(String message) {
-    return new ChatMessage(message);
+  public static ChatMessage of(String sender, String content) {
+    return ChatMessage.builder()
+                      .sender(sender)
+                      .content(content)
+                      .build();
   }
 }

--- a/backend/chat/src/main/java/com/example/service/ChatService.java
+++ b/backend/chat/src/main/java/com/example/service/ChatService.java
@@ -1,0 +1,8 @@
+package com.example.service;
+
+import com.example.dto.ChatMessage;
+
+public interface ChatService {
+
+  void send(String id, ChatMessage message);
+}

--- a/backend/chat/src/main/java/com/example/service/ChatServiceImpl.java
+++ b/backend/chat/src/main/java/com/example/service/ChatServiceImpl.java
@@ -1,0 +1,25 @@
+
+package com.example.service;
+
+import com.example.domain.Topic;
+import com.example.dto.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+
+  private final TopicService topicService;
+  private final MessagePublisher publisher;
+
+  @Override
+  public void send(String id, ChatMessage message) {
+    Topic foundTopic = topicService.findById(id);
+    publisher.publish(foundTopic.getId(), message);
+  }
+}

--- a/backend/chat/src/main/java/com/example/service/TopicService.java
+++ b/backend/chat/src/main/java/com/example/service/TopicService.java
@@ -1,10 +1,11 @@
 package com.example.service;
 
 import com.example.domain.Topic;
+import java.time.LocalDateTime;
 
 public interface TopicService {
 
-  void create(String id);
+  void create(String id, LocalDateTime expireAt);
 
   Topic findById(String id);
 }

--- a/backend/chat/src/main/java/com/example/service/TopicServiceImpl.java
+++ b/backend/chat/src/main/java/com/example/service/TopicServiceImpl.java
@@ -4,6 +4,7 @@ import static com.example.exception.ErrorMessage.NONEXISTENT_TOPIC;
 
 import com.example.domain.Topic;
 import com.example.repository.TopicRepository;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.stereotype.Service;
@@ -20,10 +21,10 @@ public class TopicServiceImpl implements TopicService {
   TODO: ttl 값 설정 필요
    */
   @Override
-  public void create(String id) {
+  public void create(String id, LocalDateTime expireAt) {
     redisMessageListenerContainer.addMessageListener(redisSubscriber,
       new org.springframework.data.redis.listener.ChannelTopic(id));
-    topicRepository.save(Topic.from(id));
+    topicRepository.save(Topic.from(id, expireAt));
   }
 
   @Override

--- a/backend/chat/src/test/java/com/example/chat/EmbeddedRedisConfig.java
+++ b/backend/chat/src/test/java/com/example/chat/EmbeddedRedisConfig.java
@@ -1,0 +1,97 @@
+package com.example.chat;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StringUtils;
+import redis.embedded.RedisServer;
+
+@Configuration
+public class EmbeddedRedisConfig {
+  @Value("${spring.data.redis.port}")
+  private int port;
+  private redis.embedded.RedisServer redisServer;
+
+
+  @PostConstruct
+  public void redisServer() throws IOException {
+    port = isRedisRunning() ? findAvailablePort() : port;
+    if (isArmMac()) {
+      redisServer = new RedisServer(Objects.requireNonNull(getRedisFileForArcMac()),
+        port);
+    }
+    if (!isArmMac()) {
+      redisServer = new RedisServer(port);
+    }
+
+    redisServer.start();
+  }
+
+  @PreDestroy
+  public void stopRedis(){
+
+    if(redisServer != null){
+      redisServer.stop();
+    }
+  }
+
+  private boolean isRedisRunning() throws IOException {
+    return isRunning(executeGrepProcessCommand(port));
+  }
+
+  public int findAvailablePort() throws IOException {
+
+    for (int port = 10000; port <= 65535; port++) {
+      Process process = executeGrepProcessCommand(port);
+      if (!isRunning(process)) {
+        return port;
+      }
+    }
+
+    throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+  }
+
+  /**
+   * 해당 port를 사용중인 프로세스 확인하는 sh 실행
+   */
+  private Process executeGrepProcessCommand(int port) throws IOException {
+    String command = String.format("netstat -nat | grep LISTEN|grep %d", port);
+    String[] shell = {"/bin/sh", "-c", command};
+    return Runtime.getRuntime().exec(shell);
+  }
+  private boolean isRunning(Process process) {
+    String line;
+    StringBuilder pidInfo = new StringBuilder();
+
+    try (BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+
+      while ((line = input.readLine()) != null) {
+        pidInfo.append(line);
+      }
+
+    } catch (Exception e) {
+    }
+
+    return StringUtils.hasText(pidInfo.toString());
+  }
+
+  private boolean isArmMac() {
+    return Objects.equals(System.getProperty("os.arch"), "aarch64") &&
+      Objects.equals(System.getProperty("os.name"), "Mac OS X");
+  }
+
+  private File getRedisFileForArcMac() {
+    try {
+      return new ClassPathResource("binary/redis/redis-server-6.2.5-mac-arm64").getFile();
+    } catch (Exception e) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/backend/chat/src/test/java/com/example/chat/controller/ChatControllerTest.java
+++ b/backend/chat/src/test/java/com/example/chat/controller/ChatControllerTest.java
@@ -1,0 +1,214 @@
+package com.example.chat.controller;
+
+import static java.lang.Thread.sleep;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import com.example.controller.ChatController;
+import com.example.dto.ChatMessage;
+import com.example.repository.TopicRepository;
+import com.example.service.TopicService;
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class ChatControllerTest {
+
+  @LocalServerPort
+  Integer port;
+
+  @SpyBean
+  ChatController chatController;
+
+  @Autowired
+  TopicRepository topicRepository;
+
+  @Autowired
+  TopicService topicService;
+  WebSocketStompClient webSocketStompClient;
+  StompSession session;
+
+
+  @BeforeEach
+  void init() throws ExecutionException, InterruptedException, TimeoutException {
+    webSocketStompClient = new WebSocketStompClient(
+      new SockJsClient(
+        List.of(new WebSocketTransport(new StandardWebSocketClient()))));
+    webSocketStompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+    session = webSocketStompClient.connectAsync(
+                                    String.format("ws://localhost:%d/ws", port),
+                                    new StompSessionHandlerAdapter() {
+                                    })
+                                  .get(1, TimeUnit.SECONDS);
+  }
+
+  @Nested
+  @DisplayName("send 메서드는")
+  class DescribeSend {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("해당 토픽을 구독한 사용자들에게 메시지를 발행한다")
+      void ItPublishesMessage() throws InterruptedException {
+        // given
+        String topicId = "topicId";
+        String subUri = String.format("/topic/%s", topicId);
+        topicService.create(topicId, LocalDateTime.now());
+
+        ChatMessage message = ChatMessage.of("user1", "hi~");
+        BlockingQueue<ChatMessage> queue = new ArrayBlockingQueue<>(1);
+        session.subscribe(subUri, new StompFrameHandler() {
+          @Override
+          public Type getPayloadType(StompHeaders headers) {
+            return ChatMessage.class;
+          }
+
+          @Override
+          public void handleFrame(StompHeaders headers, Object payload) {
+            queue.add((ChatMessage) payload);
+          }
+        });
+
+        // when
+        session.send(String.format("/chat/%s/send", topicId), message);
+
+        // then
+        ChatMessage chatMessage = queue.poll(1, TimeUnit.SECONDS);
+        assertThat(chatMessage.getContent()).isEqualTo(message.getContent());
+      }
+    }
+
+    @Nested
+    @DisplayName("메시지가 100자를 넘는다면")
+    class ContextWithMessageLengthOver100 {
+
+      @Test
+      @DisplayName("handleException을 호출한다")
+      void ItCallsHandleException() throws InterruptedException {
+        // given
+        String topicId = "topicId";
+        ChatMessage message = ChatMessage.of("user1", "s".repeat(101));
+
+        // when
+        session.send(String.format("/chat/%s/send", topicId), message);
+
+        // then
+        sleep(1000);
+        verify(chatController).handleException(any(Exception.class));
+      }
+    }
+
+    @Nested
+    @DisplayName("메시지가 빈 값이라면")
+    class ContextWithMessageEmpty {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @DisplayName("handleException을 호출한다")
+      void ItCallsHandleException(String content) throws InterruptedException {
+        // given
+        String topicId = "topicId";
+        ChatMessage message = ChatMessage.of("user1", content);
+
+        // when
+        session.send(String.format("/chat/%s/send", topicId), message);
+
+        // then
+        sleep(1000);
+        verify(chatController).handleException(any(Exception.class));
+      }
+    }
+
+    @Nested
+    @DisplayName("토픽 아이디가 null이라면")
+    class ContextWithTopicIdNull {
+
+      @Test
+      @DisplayName("handleException을 호출한다")
+      void ItCallsHandleException() throws InterruptedException {
+        // given
+        String topicId = null;
+        ChatMessage message = ChatMessage.of("user1", "hello~~!!");
+
+        // when, then
+        session.send(String.format("/chat/%s/send", topicId), message);
+
+        // then
+        sleep(1000);
+        verify(chatController).handleException(any(Exception.class));
+      }
+    }
+
+    @Nested
+    @DisplayName("송신자 닉네임이 255자를 넘는다면")
+    class ContextWithSenderLengthOver255 {
+
+      @Test
+      @DisplayName("handleException을 호출한다")
+      void ItCallsHandleException() throws InterruptedException {
+        // given
+        String topicId = "topicId";
+        ChatMessage message = ChatMessage.of("u".repeat(256), "message");
+
+        // when
+        session.send(String.format("/chat/%s/send", topicId), message);
+
+        // then
+        sleep(1000);
+        verify(chatController).handleException(any(Exception.class));
+      }
+    }
+
+    @Nested
+    @DisplayName("송신자 닉네임이 빈 값이라면")
+    class ContextWithSenderEmpty {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @DisplayName("handleException을 호출한다")
+      void ItCallsHandleException(String sender) throws InterruptedException {
+        // given
+        String topicId = "topicId";
+        ChatMessage message = ChatMessage.of(sender, "message");
+
+        // when
+        session.send(String.format("/chat/%s/send", topicId), message);
+
+        // then
+        sleep(1000);
+        verify(chatController).handleException(any(Exception.class));
+      }
+    }
+  }
+}

--- a/backend/chat/src/test/java/com/example/chat/service/ChatServiceImplTest.java
+++ b/backend/chat/src/test/java/com/example/chat/service/ChatServiceImplTest.java
@@ -1,0 +1,79 @@
+package com.example.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.example.domain.Topic;
+import com.example.dto.ChatMessage;
+import com.example.service.ChatServiceImpl;
+import com.example.service.MessagePublisher;
+import com.example.service.TopicService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceImplTest {
+
+  @Mock
+  TopicService topicService;
+
+  @Mock
+  MessagePublisher messagePublisher;
+
+  @InjectMocks
+  ChatServiceImpl chatService;
+
+  @Nested
+  @DisplayName("send 메서드는")
+  class DescribeSend {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("publisher.publish()를 호출한다")
+      void ItCallsPublish() {
+        // given
+        String id = "topic1";
+        ChatMessage message = ChatMessage.of("user1", "message1");
+        given(topicService.findById(anyString()))
+          .willReturn(Topic.from(id, LocalDateTime.now()));
+
+        // when
+        chatService.send(id, message);
+
+        // then
+        verify(messagePublisher).publish(anyString(), any(ChatMessage.class));
+      }
+    }
+
+    @Nested
+    @DisplayName("존재하지 않는 토픽이라면")
+    class ContextWithNonexistentTopic {
+
+      @Test
+      @DisplayName("IllegalArgumentException 에러를 발생시킨다")
+      void ItThrowsIllegalArgumentException() {
+        // given
+        String id = "topic1";
+        ChatMessage message = ChatMessage.of("user1", "message1");
+        given(topicService.findById(anyString()))
+          .willThrow(new IllegalArgumentException());
+
+        // when, then
+        assertThatThrownBy(() -> chatService.send(id, message))
+          .isInstanceOf(IllegalArgumentException.class);
+      }
+    }
+  }
+}

--- a/backend/chat/src/test/java/com/example/chat/service/TopicServiceImplTest.java
+++ b/backend/chat/src/test/java/com/example/chat/service/TopicServiceImplTest.java
@@ -8,7 +8,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 
-import com.example.chat.repository.TopicRepository;
+import com.example.domain.Topic;
+import com.example.repository.TopicRepository;
+import com.example.service.RedisSubscriber;
+import com.example.service.TopicServiceImpl;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -31,10 +35,10 @@ class TopicServiceImplTest {
   RedisMessageListenerContainer redisMessageListenerContainer;
 
   @Mock
-  com.example.chat.service.RedisSubscriber redisSubscriber;
+  RedisSubscriber redisSubscriber;
 
   @InjectMocks
-  com.example.chat.service.TopicServiceImpl topicService;
+  TopicServiceImpl topicService;
 
   @Nested
   @DisplayName("create 메서드는")
@@ -52,16 +56,16 @@ class TopicServiceImplTest {
         willDoNothing().given(redisMessageListenerContainer)
                        .addMessageListener(any(MessageListener.class), any(
                          ChannelTopic.class));
-        given(topicRepository.save(any(com.example.chat.domain.Topic.class)))
-          .willReturn(com.example.chat.domain.Topic.from(id));
+        given(topicRepository.save(any(Topic.class)))
+          .willReturn(Topic.from(id, LocalDateTime.now()));
 
         // when
-        topicService.create(id);
+        topicService.create(id, LocalDateTime.now());
 
         // then
         verify(redisMessageListenerContainer).addMessageListener(any(MessageListener.class), any(
           ChannelTopic.class));
-        verify(topicRepository).save(any(com.example.chat.domain.Topic.class));
+        verify(topicRepository).save(any(Topic.class));
       }
     }
   }
@@ -80,10 +84,9 @@ class TopicServiceImplTest {
         // given
         String id = "topic1";
         given(topicRepository.findById(anyString()))
-          .willReturn(Optional.of(com.example.chat.domain.Topic.from(id)));
-
+          .willReturn(Optional.of(Topic.from(id, LocalDateTime.now())));
         // when
-        com.example.chat.domain.Topic topic = topicService.findById(id);
+        Topic topic = topicService.findById(id);
 
         // then
         assertThat(topic.getId()).isEqualTo(id);


### PR DESCRIPTION
* Topic(채팅방)에 방송 종료 시간 필드 추가
* ChatMessage(채팅 메시지) 보내는 사람 닉네임 필드 추가, message -> content로 네이밍 변경
위 변경사항은 코드 변경이 크지 않아 이번 pr에 같이 올렸습니다!
---
* 메시지 전송 기능 구현
* 메시지 전송 테스트 하기 위해 embedded redis 사용
  * embedded redis 참고: https://jojoldu.tistory.com/297
  * 스프링 테스트 컨텍스트 캐싱으로 인해 발생하는 문제 해결 위해서 추가 코드가 필요하므로 추후 test container를 사용하는 방법 고려 예정