### PR TITLE
[AI-31] 채팅 데이터 저장

### DIFF
--- a/backend/chat/build.gradle
+++ b/backend/chat/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
     testImplementation "org.testcontainers:testcontainers:1.17.6"
     testImplementation "org.testcontainers:junit-jupiter:1.17.6"
+    testImplementation "org.testcontainers:mongodb:1.17.6"
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/backend/chat/src/main/java/com/example/ChatApplication.java
+++ b/backend/chat/src/main/java/com/example/ChatApplication.java
@@ -2,8 +2,10 @@ package com.example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @SpringBootApplication
+@EnableMongoAuditing
 public class ChatApplication {
 
   public static void main(String[] args) {

--- a/backend/chat/src/main/java/com/example/controller/ChatController.java
+++ b/backend/chat/src/main/java/com/example/controller/ChatController.java
@@ -1,6 +1,6 @@
 package com.example.controller;
 
-import com.example.dto.ChatMessage;
+import com.example.dto.ChatMessageRequest;
 import com.example.service.ChatService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
@@ -20,7 +20,7 @@ public class ChatController {
 
 
   @MessageMapping("/{id}/send")
-  public void send(@DestinationVariable @NotEmpty String id, @Valid ChatMessage message) {
+  public void send(@DestinationVariable @NotEmpty String id, @Valid ChatMessageRequest message) {
     chatService.send(id, message);
   }
 

--- a/backend/chat/src/main/java/com/example/domain/Message.java
+++ b/backend/chat/src/main/java/com/example/domain/Message.java
@@ -1,0 +1,40 @@
+package com.example.domain;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "message")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class Message {
+
+  @Id
+  private String id;
+
+  private String topicId;
+
+  private String sender;
+
+  private String content;
+
+  @CreatedDate
+  LocalDateTime createAt;
+
+  @Indexed(expireAfterSeconds = 0)
+  private LocalDateTime expireAt;
+
+  public static Message of(String topicId, String sender, String content, LocalDateTime expireAt) {
+    return Message.builder()
+                  .topicId(topicId)
+                  .sender(sender)
+                  .content(content)
+                  .expireAt(expireAt)
+                  .build();
+  }
+}

--- a/backend/chat/src/main/java/com/example/dto/ChatMessageRequest.java
+++ b/backend/chat/src/main/java/com/example/dto/ChatMessageRequest.java
@@ -4,16 +4,13 @@ import static lombok.AccessLevel.PRIVATE;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
-import java.io.Serializable;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = PRIVATE)
-public class ChatMessage implements Serializable {
-
-  private static final long serialVersionUID = 6494678977089006639L;
+public class ChatMessageRequest {
 
   @NotEmpty
   @Size(max = 255, message = "닉네임 길이는 최대 255자입니다.")
@@ -24,15 +21,15 @@ public class ChatMessage implements Serializable {
   private String content;
 
   @Builder(access = PRIVATE)
-  private ChatMessage(String sender, String content) {
+  private ChatMessageRequest(String sender, String content) {
     this.sender = sender;
     this.content = content;
   }
 
-  public static ChatMessage of(String sender, String content) {
-    return ChatMessage.builder()
-                      .sender(sender)
-                      .content(content)
-                      .build();
+  public static ChatMessageRequest of(String sender, String content) {
+    return ChatMessageRequest.builder()
+                             .sender(sender)
+                             .content(content)
+                             .build();
   }
 }

--- a/backend/chat/src/main/java/com/example/dto/ChatMessageResponse.java
+++ b/backend/chat/src/main/java/com/example/dto/ChatMessageResponse.java
@@ -1,0 +1,30 @@
+package com.example.dto;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import java.io.Serializable;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+public class ChatMessageResponse implements Serializable {
+  private static final long serialVersionUID = 6494678977089006639L;
+
+  private String sender;
+  private String content;
+
+  @Builder(access = PRIVATE)
+  public ChatMessageResponse(String sender, String content) {
+    this.sender = sender;
+    this.content = content;
+  }
+
+  public static ChatMessageResponse of(String sender, String content) {
+    return ChatMessageResponse.builder()
+                              .sender(sender)
+                              .content(content)
+                              .build();
+  }
+}

--- a/backend/chat/src/main/java/com/example/repository/ChatRepository.java
+++ b/backend/chat/src/main/java/com/example/repository/ChatRepository.java
@@ -1,0 +1,8 @@
+package com.example.repository;
+
+import com.example.domain.Message;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ChatRepository extends CrudRepository<Message, String> {
+
+}

--- a/backend/chat/src/main/java/com/example/service/ChatService.java
+++ b/backend/chat/src/main/java/com/example/service/ChatService.java
@@ -1,8 +1,8 @@
 package com.example.service;
 
-import com.example.dto.ChatMessage;
+import com.example.dto.ChatMessageRequest;
 
 public interface ChatService {
 
-  void send(String id, ChatMessage message);
+  void send(String id, ChatMessageRequest message);
 }

--- a/backend/chat/src/main/java/com/example/service/ChatServiceImpl.java
+++ b/backend/chat/src/main/java/com/example/service/ChatServiceImpl.java
@@ -1,25 +1,30 @@
 
 package com.example.service;
 
+import com.example.domain.Message;
 import com.example.domain.Topic;
-import com.example.dto.ChatMessage;
+import com.example.dto.ChatMessageRequest;
+import com.example.repository.ChatRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ChatServiceImpl implements ChatService {
 
   private final TopicService topicService;
   private final MessagePublisher publisher;
 
+  private final ChatRepository chatRepository;
+
   @Override
-  public void send(String id, ChatMessage message) {
+  public void send(String id, ChatMessageRequest message) {
     Topic foundTopic = topicService.findById(id);
+    Message sendMessage = Message.of(foundTopic.getId(), message.getSender(), message.getContent(),
+      foundTopic.getExpireAt());
+    chatRepository.save(sendMessage);
     publisher.publish(foundTopic.getId(), message);
   }
 }

--- a/backend/chat/src/main/java/com/example/service/MessagePublisher.java
+++ b/backend/chat/src/main/java/com/example/service/MessagePublisher.java
@@ -1,9 +1,9 @@
 package com.example.service;
 
 
-import com.example.dto.ChatMessage;
+import com.example.dto.ChatMessageRequest;
 
 public interface MessagePublisher {
 
-  void publish(String topic, ChatMessage message);
+  void publish(String topic, ChatMessageRequest message);
 }

--- a/backend/chat/src/main/java/com/example/service/RedisPublisher.java
+++ b/backend/chat/src/main/java/com/example/service/RedisPublisher.java
@@ -1,6 +1,6 @@
 package com.example.service;
 
-import com.example.dto.ChatMessage;
+import com.example.dto.ChatMessageRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -12,7 +12,7 @@ public class RedisPublisher implements MessagePublisher {
   private final RedisTemplate<String, Object> redisTemplate;
 
   @Override
-  public void publish(String topic, ChatMessage message) {
+  public void publish(String topic, ChatMessageRequest message) {
     redisTemplate.convertAndSend(topic, message);
   }
 }

--- a/backend/chat/src/main/java/com/example/service/RedisSubscriber.java
+++ b/backend/chat/src/main/java/com/example/service/RedisSubscriber.java
@@ -1,6 +1,7 @@
 package com.example.service;
 
-import com.example.dto.ChatMessage;
+import com.example.dto.ChatMessageRequest;
+import com.example.dto.ChatMessageResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -26,13 +27,15 @@ public class RedisSubscriber implements MessageListener {
     String id = redisTemplate.getStringSerializer().deserialize(message.getChannel());
     String messageBody = redisTemplate.getStringSerializer()
                                       .deserialize(message.getBody());
-    ChatMessage chatMessage = null;
+    ChatMessageRequest chatMessage = null;
     try {
-      chatMessage = objectMapper.readValue(messageBody, ChatMessage.class);
+      chatMessage = objectMapper.readValue(messageBody, ChatMessageRequest.class);
     } catch (JsonProcessingException e) {
       log.info(e.getMessage());
       return;
     }
-    simpMessageSendingOperations.convertAndSend("/topic/" + id, chatMessage);
+    ChatMessageResponse sendChatMessage = ChatMessageResponse.of(chatMessage.getSender(),
+      chatMessage.getContent());
+    simpMessageSendingOperations.convertAndSend("/topic/" + id, sendChatMessage);
   }
 }

--- a/backend/chat/src/main/resources/application.yml
+++ b/backend/chat/src/main/resources/application.yml
@@ -3,5 +3,9 @@ spring:
     redis:
       host: localhost
       port: 8090
+    mongodb:
+      host: localhost
+      port: 27017
+      database: chat
   main:
     allow-bean-definition-overriding: true

--- a/backend/chat/src/test/java/com/example/chat/MongoTestContainerConfig.java
+++ b/backend/chat/src/test/java/com/example/chat/MongoTestContainerConfig.java
@@ -1,0 +1,39 @@
+package com.example.chat;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.ModifierSupport;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class MongoTestContainerConfig implements BeforeAllCallback {
+
+  private static final String MONGO_IMAGE = "mongo:5.0.14";
+
+  private static final int MONGO_PORT = 27017;
+
+  private MongoDBContainer mongoDB;
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    if (context.getTestClass().isPresent()) {
+      Class<?> currentClass = context.getTestClass().get();
+      if (isNestedClass(currentClass)) {
+        return;
+      }
+    }
+
+    mongoDB = new MongoDBContainer(DockerImageName.parse(MONGO_IMAGE))
+      .withExposedPorts(MONGO_PORT);
+    mongoDB.start();
+    System.setProperty("spring.data.mongodb.host", mongoDB.getHost());
+    System.setProperty("spring.data.mongodb.port", String.valueOf(mongoDB.getMappedPort(MONGO_PORT
+    )));
+
+  }
+
+  private boolean isNestedClass(Class<?> currentClass) {
+    return !ModifierSupport.isStatic(currentClass) && currentClass.isMemberClass();
+  }
+
+}

--- a/backend/chat/src/test/java/com/example/chat/RedisTestContainerConfig.java
+++ b/backend/chat/src/test/java/com/example/chat/RedisTestContainerConfig.java
@@ -1,12 +1,12 @@
-package com.example.chat.controller;
+package com.example.chat;
 
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.ModifierSupport;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
-public class TestContainerConfig implements BeforeAllCallback {
+public class RedisTestContainerConfig implements BeforeAllCallback {
 
   private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
   private static final int REDIS_PORT = 6379;
@@ -14,11 +14,21 @@ public class TestContainerConfig implements BeforeAllCallback {
 
   @Override
   public void beforeAll(ExtensionContext context) {
+    if (context.getTestClass().isPresent()) {
+      Class<?> currentClass = context.getTestClass().get();
+      if (isNestedClass(currentClass)) {
+        return;
+      }
+    }
     redis = new GenericContainer(DockerImageName.parse(REDIS_IMAGE))
       .withExposedPorts(REDIS_PORT);
     redis.start();
     System.setProperty("spring.data.redis.host", redis.getHost());
     System.setProperty("spring.data.redis.port", String.valueOf(redis.getMappedPort(REDIS_PORT
     )));
+  }
+
+  private boolean isNestedClass(Class<?> currentClass) {
+    return !ModifierSupport.isStatic(currentClass) && currentClass.isMemberClass();
   }
 }

--- a/backend/chat/src/test/resources/application.yml
+++ b/backend/chat/src/test/resources/application.yml
@@ -3,5 +3,9 @@ spring:
     redis:
       host: localhost
       port: 6379
+    mongodb:
+      host: localhost
+      port: 27017
+      database: chat
   main:
     allow-bean-definition-overriding: true


### PR DESCRIPTION
* dto인 ChatMessage의 이름을 더 역할이 잘 보이는 이름(ChatMessageRequest)으로 변경하였습니다. 
* 클라이언트에게 응답 보내기 위한 ChatMessageResponse dto 클래스를 생성하여 기존에 ChatMessage로 응답을 보내던 부분을 수정하였습니다.
* 추후 채팅 데이터 이력 조회api에서 최신순으로 메시지를 DB에서 조회해오기 위해 메시지 저장시 생성 시간을 자동으로 추가해주는 Auditing 을 추가하였습니다.
---
* 채팅 데이터 저장 코드 를 구현하였고 testcontainer를 사용하여 테스트했습니다.
* 이전에 레디스, 몽고 testcontainer 설정을 하나의 클래스(TestContainerConfig)로 했던 것을 레디스 설정, 몽고 설정 각각 두개로 분리하였습니다. (RedisTestContainerConfig, MongoTestContainerConfig)