### PR TITLE
[AI-29] 채팅 이력 조회 구현

### DIFF
--- a/backend/chat/src/main/java/com/example/controller/api/ChatApiController.java
+++ b/backend/chat/src/main/java/com/example/controller/api/ChatApiController.java
@@ -1,0 +1,25 @@
+package com.example.controller.api;
+
+import com.example.dto.ApiResponse;
+import com.example.dto.ChatMessagePagingRequest;
+import com.example.dto.ChatMessageResponse;
+import com.example.service.ChatService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/chats")
+@RequiredArgsConstructor
+public class ChatApiController {
+  private final ChatService chatService;
+
+  @GetMapping
+  ApiResponse<List<ChatMessageResponse>> findAll(@ModelAttribute @Valid ChatMessagePagingRequest request) {
+    return new ApiResponse<>(chatService.findAll(request));
+  }
+}

--- a/backend/chat/src/main/java/com/example/controller/api/ChatApiController.java
+++ b/backend/chat/src/main/java/com/example/controller/api/ChatApiController.java
@@ -9,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,8 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatApiController {
   private final ChatService chatService;
 
-  @GetMapping
-  ApiResponse<List<ChatMessageResponse>> findAll(@ModelAttribute @Valid ChatMessagePagingRequest request) {
-    return new ApiResponse<>(chatService.findAll(request));
+  @GetMapping("{topicId}")
+  ApiResponse<List<ChatMessageResponse>> findAll(@PathVariable String topicId, @ModelAttribute @Valid ChatMessagePagingRequest request) {
+    return new ApiResponse<>(chatService.findAll(topicId, request));
   }
 }

--- a/backend/chat/src/main/java/com/example/domain/Message.java
+++ b/backend/chat/src/main/java/com/example/domain/Message.java
@@ -1,5 +1,8 @@
 package com.example.domain;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,15 +20,21 @@ public class Message {
   @Id
   private String id;
 
+  @NotBlank
   private String topicId;
 
+  @NotBlank
+  @Size(max = 255)
   private String sender;
 
+  @NotBlank
+  @Size(max = 100)
   private String content;
 
   @CreatedDate
   LocalDateTime createAt;
 
+  @NotNull
   @Indexed(expireAfterSeconds = 0)
   private LocalDateTime expireAt;
 

--- a/backend/chat/src/main/java/com/example/domain/Topic.java
+++ b/backend/chat/src/main/java/com/example/domain/Topic.java
@@ -1,5 +1,6 @@
 package com.example.domain;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -15,6 +16,7 @@ public class Topic {
   @Id
   private final String id;
 
+  @NotNull
   private final LocalDateTime expireAt;
 
   public static Topic from(String id, LocalDateTime expireAt) {

--- a/backend/chat/src/main/java/com/example/dto/ApiResponse.java
+++ b/backend/chat/src/main/java/com/example/dto/ApiResponse.java
@@ -1,0 +1,11 @@
+package com.example.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiResponse<T> {
+
+  private final T data;
+}

--- a/backend/chat/src/main/java/com/example/dto/ApiResponse.java
+++ b/backend/chat/src/main/java/com/example/dto/ApiResponse.java
@@ -7,5 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ApiResponse<T> {
 
+  private final String result = "success";
   private final T data;
 }

--- a/backend/chat/src/main/java/com/example/dto/ChatMessagePagingRequest.java
+++ b/backend/chat/src/main/java/com/example/dto/ChatMessagePagingRequest.java
@@ -1,0 +1,13 @@
+package com.example.dto;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatMessagePagingRequest {
+
+  @PositiveOrZero(message = "page는 양수이거나 0이어야합니다.")
+  private final int page;
+}

--- a/backend/chat/src/main/java/com/example/exception/ErrorMessage.java
+++ b/backend/chat/src/main/java/com/example/exception/ErrorMessage.java
@@ -7,6 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public enum ErrorMessage {
-  NONEXISTENT_TOPIC("존재하지 않는 topic입니다.");
+  REQUEST_DATA_NOT_FOUND("001", "요청 데이터가 올바르지 않습니다."),
+  NONEXISTENT_TOPIC("002", "존재하지 않는 topic입니다.");
+
+  private final String code;
   private final String message;
 }

--- a/backend/chat/src/main/java/com/example/exception/ExceptionController.java
+++ b/backend/chat/src/main/java/com/example/exception/ExceptionController.java
@@ -1,6 +1,8 @@
 package com.example.exception;
 
 
+import static com.example.exception.ErrorMessage.REQUEST_DATA_NOT_FOUND;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
@@ -13,12 +15,17 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseBody
 @Slf4j
 public class ExceptionController {
-
+  private static final String SERVER_NUM = "5";
   @ExceptionHandler(BindException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  public ExceptionResponse handleBindException(
-    BindException e) {
+  public ExceptionResponse handleBindException(BindException e) {
     log.warn("handleBindException: {}", e);
-    return ExceptionResponse.from(e.getMessage());
+    return ExceptionResponse.of(calculateCode(HttpStatus.BAD_REQUEST,
+        REQUEST_DATA_NOT_FOUND.getCode()),
+      e.getClass().getName(), REQUEST_DATA_NOT_FOUND.getMessage());
+  }
+
+  private String calculateCode(HttpStatus status, String code) {
+    return status.value() + SERVER_NUM + code;
   }
 }

--- a/backend/chat/src/main/java/com/example/exception/ExceptionController.java
+++ b/backend/chat/src/main/java/com/example/exception/ExceptionController.java
@@ -1,0 +1,24 @@
+package com.example.exception;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+@ResponseBody
+@Slf4j
+public class ExceptionController {
+
+  @ExceptionHandler(BindException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ExceptionResponse handleBindException(
+    BindException e) {
+    log.warn("handleBindException: {}", e);
+    return ExceptionResponse.from(e.getMessage());
+  }
+}

--- a/backend/chat/src/main/java/com/example/exception/ExceptionController.java
+++ b/backend/chat/src/main/java/com/example/exception/ExceptionController.java
@@ -1,6 +1,7 @@
 package com.example.exception;
 
 
+import static com.example.exception.ErrorMessage.NONEXISTENT_TOPIC;
 import static com.example.exception.ErrorMessage.REQUEST_DATA_NOT_FOUND;
 
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,14 @@ public class ExceptionController {
       e.getClass().getName(), REQUEST_DATA_NOT_FOUND.getMessage());
   }
 
+  @ExceptionHandler(IllegalArgumentException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ExceptionResponse handleIllegalArgumentException(IllegalArgumentException e) {
+    log.warn("handleIllegalArgumentException: {}", e);
+    return ExceptionResponse.of(calculateCode(HttpStatus.BAD_REQUEST,
+        NONEXISTENT_TOPIC.getCode()),
+      e.getClass().getName(), NONEXISTENT_TOPIC.getMessage());
+  }
   private String calculateCode(HttpStatus status, String code) {
     return status.value() + SERVER_NUM + code;
   }

--- a/backend/chat/src/main/java/com/example/exception/ExceptionResponse.java
+++ b/backend/chat/src/main/java/com/example/exception/ExceptionResponse.java
@@ -1,0 +1,16 @@
+package com.example.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ExceptionResponse {
+
+  private final String message;
+
+  public static ExceptionResponse from(String message) {
+    return new ExceptionResponse(message);
+  }
+}

--- a/backend/chat/src/main/java/com/example/exception/ExceptionResponse.java
+++ b/backend/chat/src/main/java/com/example/exception/ExceptionResponse.java
@@ -1,5 +1,7 @@
 package com.example.exception;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -8,9 +10,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ExceptionResponse {
 
+  private final Timestamp timestamp;
+  private final String code;
+  private final String error;
   private final String message;
 
-  public static ExceptionResponse from(String message) {
-    return new ExceptionResponse(message);
+  public static ExceptionResponse of(String code, String error, String message) {
+    return new ExceptionResponse(Timestamp.valueOf(LocalDateTime.now()), code, error, message);
   }
 }

--- a/backend/chat/src/main/java/com/example/repository/ChatRepository.java
+++ b/backend/chat/src/main/java/com/example/repository/ChatRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
 public interface ChatRepository extends CrudRepository<Message, String> {
-  List<Message> findAll(Pageable pageable);
+  List<Message> findAllByTopicId(String topicId, Pageable pageable);
 }

--- a/backend/chat/src/main/java/com/example/repository/ChatRepository.java
+++ b/backend/chat/src/main/java/com/example/repository/ChatRepository.java
@@ -1,8 +1,10 @@
 package com.example.repository;
 
 import com.example.domain.Message;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
 public interface ChatRepository extends CrudRepository<Message, String> {
-
+  List<Message> findAll(Pageable pageable);
 }

--- a/backend/chat/src/main/java/com/example/service/ChatService.java
+++ b/backend/chat/src/main/java/com/example/service/ChatService.java
@@ -1,8 +1,12 @@
 package com.example.service;
 
+import com.example.dto.ChatMessagePagingRequest;
 import com.example.dto.ChatMessageRequest;
+import com.example.dto.ChatMessageResponse;
+import java.util.List;
 
 public interface ChatService {
 
   void send(String id, ChatMessageRequest message);
+  List<ChatMessageResponse> findAll(ChatMessagePagingRequest request);
 }

--- a/backend/chat/src/main/java/com/example/service/ChatService.java
+++ b/backend/chat/src/main/java/com/example/service/ChatService.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface ChatService {
 
   void send(String id, ChatMessageRequest message);
-  List<ChatMessageResponse> findAll(ChatMessagePagingRequest request);
+  List<ChatMessageResponse> findAll(String topicId, ChatMessagePagingRequest request);
 }

--- a/backend/chat/src/main/java/com/example/service/ChatServiceImpl.java
+++ b/backend/chat/src/main/java/com/example/service/ChatServiceImpl.java
@@ -37,9 +37,10 @@ public class ChatServiceImpl implements ChatService {
   }
 
   @Override
-  public List<ChatMessageResponse> findAll(ChatMessagePagingRequest request) {
+  public List<ChatMessageResponse> findAll(String topicId, ChatMessagePagingRequest request) {
+    Topic topic = topicService.findById(topicId);
     Pageable page = PageRequest.of(request.getPage(), PAGE_SIZE, Sort.by("createAt").descending());
-    return chatRepository.findAll(page)
+    return chatRepository.findAllByTopicId(topic.getId(), page)
                          .stream()
                          .map(
                            (message) -> ChatMessageResponse.of(message.getSender(),

--- a/backend/chat/src/main/java/com/example/service/ChatServiceImpl.java
+++ b/backend/chat/src/main/java/com/example/service/ChatServiceImpl.java
@@ -3,10 +3,17 @@ package com.example.service;
 
 import com.example.domain.Message;
 import com.example.domain.Topic;
+import com.example.dto.ChatMessagePagingRequest;
 import com.example.dto.ChatMessageRequest;
+import com.example.dto.ChatMessageResponse;
 import com.example.repository.ChatRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,6 +21,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ChatServiceImpl implements ChatService {
 
+  private static final int PAGE_SIZE = 19;
   private final TopicService topicService;
   private final MessagePublisher publisher;
 
@@ -26,5 +34,16 @@ public class ChatServiceImpl implements ChatService {
       foundTopic.getExpireAt());
     chatRepository.save(sendMessage);
     publisher.publish(foundTopic.getId(), message);
+  }
+
+  @Override
+  public List<ChatMessageResponse> findAll(ChatMessagePagingRequest request) {
+    Pageable page = PageRequest.of(request.getPage(), PAGE_SIZE, Sort.by("createAt").descending());
+    return chatRepository.findAll(page)
+                         .stream()
+                         .map(
+                           (message) -> ChatMessageResponse.of(message.getSender(),
+                             message.getContent()))
+                         .collect(Collectors.toList());
   }
 }

--- a/backend/chat/src/test/java/com/example/chat/controller/api/ChatApiControllerTest.java
+++ b/backend/chat/src/test/java/com/example/chat/controller/api/ChatApiControllerTest.java
@@ -1,0 +1,104 @@
+package com.example.chat.controller.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.controller.api.ChatApiController;
+import com.example.domain.Message;
+import com.example.dto.ApiResponse;
+import com.example.dto.ChatMessagePagingRequest;
+import com.example.dto.ChatMessageResponse;
+import com.example.service.ChatService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+
+@AutoConfigureDataMongo
+@WebMvcTest(controllers = ChatApiController.class)
+class ChatApiControllerTest {
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private ChatService chatService;
+
+  @Nested
+  @DisplayName("findAll 메서드는")
+  class DescribeFindAll {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("채팅 메시지 목록을 반환한다")
+      void ItReturnsChatMessageList() throws Exception {
+        // given
+        List<Message> messages = createChatMessage();
+        List<ChatMessageResponse> chatMessages = messages.stream()
+                                                         .map((m) -> ChatMessageResponse.of(
+                                                           m.getSender(), m.getContent()))
+                                                         .collect(Collectors.toList());
+        String expectedResponse = objectMapper.writeValueAsString(new ApiResponse<>(chatMessages));
+        given(chatService.findAll(any(ChatMessagePagingRequest.class)))
+          .willReturn(chatMessages);
+
+        // when, then
+        LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("page", "0");
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/chats")
+                                              .params(params))
+                                              .andExpect(status().isOk())
+                                              .andExpect(content().json(expectedResponse));
+      }
+    }
+
+    @Nested
+    @DisplayName("페이지가 음수라면")
+    class ContextWithPageNegative {
+
+      @Test
+      @DisplayName("예외 메시지를 반환한다")
+      void ItThrowsExceptionResponse() throws Exception {
+        // given
+        // when, then
+        LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("page", "-1");
+        MockHttpServletResponse res = mockMvc.perform(
+                                               MockMvcRequestBuilders.get("/api/v1/chats")
+                                                                     .params(params))
+                                                                     .andExpect(status().is4xxClientError())
+                                                                     .andReturn().getResponse();
+        res.getContentAsString().contains("page는 양수이거나 0이어야합니다.");
+      }
+    }
+  }
+
+  private List<Message> createChatMessage() {
+    List<Message> messages = new LinkedList<>();
+    for (int i = 0; i < 20; i++) {
+      Message message = Message.of("topic1", "마틴파울러", "hi~", LocalDateTime.now().plusMinutes(10));
+      messages.add(message);
+    }
+    return messages;
+  }
+}

--- a/backend/chat/src/test/java/com/example/chat/repository/ChatRepositoryTest.java
+++ b/backend/chat/src/test/java/com/example/chat/repository/ChatRepositoryTest.java
@@ -37,7 +37,7 @@ class ChatRepositoryTest {
         createChatMessage();
 
         // when
-        List<Message> result = chatRepository.findAll(PageRequest.of(0, 19));
+        List<Message> result = chatRepository.findAllByTopicId("topic1", PageRequest.of(0, 19));
 
         // then
         assertThat(result.size()).isEqualTo(19);

--- a/backend/chat/src/test/java/com/example/chat/repository/ChatRepositoryTest.java
+++ b/backend/chat/src/test/java/com/example/chat/repository/ChatRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.example.chat.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.chat.MongoTestContainerConfig;
+import com.example.domain.Message;
+import com.example.repository.ChatRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MongoTestContainerConfig.class)
+@DataMongoTest
+class ChatRepositoryTest {
+
+  @Autowired
+  ChatRepository chatRepository;
+
+  @Nested
+  @DisplayName("findAll 메서드는")
+  class DescribeFindAll {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("채팅 메시지 리스트를 반환한다")
+      void ItReturnsChatMessageList() {
+        // given
+        createChatMessage();
+
+        // when
+        List<Message> result = chatRepository.findAll(PageRequest.of(0, 19));
+
+        // then
+        assertThat(result.size()).isEqualTo(19);
+      }
+    }
+  }
+
+  private void createChatMessage() {
+    for (int i = 0; i < 20; i++) {
+      Message message = Message.of("topic1", "마틴파울러", "hi~", LocalDateTime.now().plusMinutes(10));
+      chatRepository.save(message);
+    }
+  }
+}

--- a/backend/chat/src/test/java/com/example/chat/service/ChatServiceImplTest.java
+++ b/backend/chat/src/test/java/com/example/chat/service/ChatServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.example.chat.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -8,12 +9,16 @@ import static org.mockito.Mockito.verify;
 
 import com.example.domain.Message;
 import com.example.domain.Topic;
+import com.example.dto.ChatMessagePagingRequest;
 import com.example.dto.ChatMessageRequest;
+import com.example.dto.ChatMessageResponse;
 import com.example.repository.ChatRepository;
 import com.example.service.ChatServiceImpl;
 import com.example.service.MessagePublisher;
 import com.example.service.TopicService;
 import java.time.LocalDateTime;
+import java.util.LinkedList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class ChatServiceImplTest {
@@ -82,5 +88,39 @@ class ChatServiceImplTest {
           .isInstanceOf(IllegalArgumentException.class);
       }
     }
+  }
+
+  @Nested
+  @DisplayName("findAll 메서드는")
+  class DescribeFindAll {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("채팅 메시지 리스트를 반환한다")
+      void ItReturnsChatMessageList() {
+        // given
+        List<Message> messages = createChatMessage();
+        given(chatRepository.findAll(any(Pageable.class)))
+          .willReturn(messages);
+
+        // when
+        List<ChatMessageResponse> result = chatService.findAll(new ChatMessagePagingRequest(0));
+
+        // then
+        assertThat(result.size()).isEqualTo(messages.size());
+      }
+    }
+  }
+
+  private List<Message> createChatMessage() {
+    List<Message> messages = new LinkedList<>();
+    for (int i = 0; i < 20; i++) {
+      Message message = Message.of("topic1", "마틴파울러", "hi~", LocalDateTime.now().plusMinutes(10));
+      messages.add(message);
+    }
+    return messages;
   }
 }


### PR DESCRIPTION
* 메시지(Message), 채팅방(Topic) 에 대한 validation 어노테이션을 추가하였습니다.
* 성공 응답시에 결과를 알려주는 result 필드를 추가하였습니다. (회의 이후 수정)
* 실패 응답을 수정하였습니다. (회의 이후 수정)
---
* 조회 기능 구현 및 테스트 