### PR TITLE
[AI-55] 채팅서버와 신고서버 kafka 구현

### DIFF
--- a/backend/chat/build.gradle
+++ b/backend/chat/build.gradle
@@ -24,10 +24,10 @@ ext {
 }
 
 dependencies {
-
-
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+//    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    testImplementation "org.testcontainers:kafka:1.17.6"
+    implementation 'org.springframework.kafka:spring-kafka'
     testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
     testImplementation "org.testcontainers:testcontainers:1.17.6"
     testImplementation "org.testcontainers:junit-jupiter:1.17.6"

--- a/backend/chat/src/main/java/com/example/config/CommonConfig.java
+++ b/backend/chat/src/main/java/com/example/config/CommonConfig.java
@@ -1,11 +1,15 @@
 package com.example.config;
 
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@EnableConfigurationProperties(value = {RedisConfig.class})
 @EnableRedisRepositories
 @EnableMongoAuditing
-@EnableDiscoveryClient
+//@EnableDiscoveryClient
+@Configuration
 public class CommonConfig {
 
 }

--- a/backend/chat/src/main/java/com/example/config/RedisConfig.java
+++ b/backend/chat/src/main/java/com/example/config/RedisConfig.java
@@ -3,11 +3,11 @@ package com.example.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -20,8 +20,11 @@ public class RedisConfig {
 
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
-    return new LettuceConnectionFactory(host, port);
+    RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration();
+    clusterConfiguration.clusterNode(host, port);
+    return new LettuceConnectionFactory(clusterConfiguration);
   }
+
 
   @Bean
   public RedisMessageListenerContainer redisMessageListenerContainer(

--- a/backend/chat/src/main/java/com/example/config/WebSocketConfig.java
+++ b/backend/chat/src/main/java/com/example/config/WebSocketConfig.java
@@ -1,6 +1,5 @@
 package com.example.config;
 
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -8,7 +7,6 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
-@EnableConfigurationProperties(value = {RedisConfig.class})
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 

--- a/backend/chat/src/main/java/com/example/domain/User.java
+++ b/backend/chat/src/main/java/com/example/domain/User.java
@@ -1,0 +1,41 @@
+package com.example.domain;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@RedisHash
+public class User {
+
+  @Id
+  private final String id;
+
+  @NotNull
+  @Indexed
+  private final String topicId;
+
+  @NotNull
+  @Indexed
+  private final String name;
+
+  @Indexed
+  private boolean isDone;
+
+  public static User of(String topicId, String name) {
+    return User.builder()
+               .topicId(topicId)
+               .name(name)
+               .isDone(false)
+               .build();
+  }
+
+  public void done() {
+    isDone = true;
+  }
+}

--- a/backend/chat/src/main/java/com/example/repository/UserRepository.java
+++ b/backend/chat/src/main/java/com/example/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.example.repository;
+
+import com.example.domain.User;
+import org.springframework.data.repository.CrudRepository;
+
+public interface UserRepository extends CrudRepository<User, String> {
+
+}

--- a/backend/chat/src/main/java/com/example/service/ReportConsumer.java
+++ b/backend/chat/src/main/java/com/example/service/ReportConsumer.java
@@ -1,0 +1,21 @@
+package com.example.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportConsumer {
+
+  private final UserService userService;
+
+  @KafkaListener(
+    topics = "${spring.kafka.topicName}",
+    groupId = "${spring.kafka.consumer.group-id}"
+  )
+
+  public void consume(ReportEvent reportEvent) {
+    userService.block(reportEvent.getTopicId(), reportEvent.getReportedUser());
+  }
+}

--- a/backend/chat/src/main/java/com/example/service/ReportEvent.java
+++ b/backend/chat/src/main/java/com/example/service/ReportEvent.java
@@ -1,0 +1,22 @@
+package com.example.service;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+class ReportEvent {
+
+  @NotEmpty
+  private String topicId;
+  @NotEmpty
+  private String reportedUser;
+
+  public ReportEvent(String topicId, String reportedUser) {
+    this.topicId = topicId;
+    this.reportedUser = reportedUser;
+  }
+}

--- a/backend/chat/src/main/java/com/example/service/UserService.java
+++ b/backend/chat/src/main/java/com/example/service/UserService.java
@@ -1,0 +1,6 @@
+package com.example.service;
+
+public interface UserService {
+
+  void block(String topicId, String name);
+}

--- a/backend/chat/src/main/java/com/example/service/UserServiceImpl.java
+++ b/backend/chat/src/main/java/com/example/service/UserServiceImpl.java
@@ -1,0 +1,18 @@
+package com.example.service;
+
+import com.example.domain.User;
+import com.example.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public void block(String topicId, String name) {
+    userRepository.save(User.of(topicId, name));
+  }
+}

--- a/backend/chat/src/main/resources/application.yml
+++ b/backend/chat/src/main/resources/application.yml
@@ -12,11 +12,32 @@ spring:
       database: ${MONGO_DATABASE}
   main:
     allow-bean-definition-overriding: true
-eureka:
-  client:
-    serviceUrl:
-      defaultZone: ${EUREKA_URI}
-    instance:
-      prefer-ip-address: true
+
+  kafka:
+    consumer:
+      bootstrap-servers: ${KAFKA_SERVER}
+      group-id: chat
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        spring:
+          json:
+            type:
+              mapping: reportEvent:com.example.service.ReportEvent
+            trusted:
+              packages: '*'
+          deserializer:
+            value:
+              delegate:
+                class: org.springframework.kafka.support.serializer.JsonDeserializer
+    topicName: report_topics
+
+#eureka:
+#  client:
+#    serviceUrl:
+#      defaultZone: ${EUREKA_URI}
+#    instance:
+#      prefer-ip-address: true
 server:
   port: 9000

--- a/backend/chat/src/test/java/com/example/chat/service/UserServiceImplTest.java
+++ b/backend/chat/src/test/java/com/example/chat/service/UserServiceImplTest.java
@@ -1,0 +1,52 @@
+package com.example.chat.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.example.domain.User;
+import com.example.repository.UserRepository;
+import com.example.service.UserServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+  @Mock
+  UserRepository userRepository;
+
+  @InjectMocks
+  UserServiceImpl userService;
+
+  @Nested
+  @DisplayName("block 메서드는")
+  class DescribeBlock {
+
+    @Nested
+    @DisplayName("유효한 값이 전달되면")
+    class ContextWithValidData {
+
+      @Test
+      @DisplayName("저장된 정보를 이용해 차단 사용자를 저장한다")
+      void ItSavesUser() {
+        // given
+        String topicId = "topic1";
+        String blockedUser = "user2";
+        given(userRepository.save(any(User.class)))
+          .willReturn(User.of(topicId, blockedUser));
+
+        // when
+        userService.block(topicId, blockedUser);
+
+        // then
+        verify(userRepository).save(any(User.class));
+      }
+    }
+  }
+}

--- a/backend/report/build.gradle
+++ b/backend/report/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
     implementation 'org.testcontainers:mysql:1.17.6'
+    implementation 'org.springframework.kafka:spring-kafka'
     testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
     testImplementation "org.testcontainers:testcontainers:1.17.6"
     testImplementation "org.testcontainers:junit-jupiter:1.17.6"
@@ -29,7 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/backend/report/src/main/java/com/example/config/CommonConfig.java
+++ b/backend/report/src/main/java/com/example/config/CommonConfig.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-@EnableConfigurationProperties(value = {RedisConfig.class})
+@EnableConfigurationProperties(value = {RedisConfig.class, KafkaTopicConfig.class})
 public class CommonConfig {
 
 }

--- a/backend/report/src/main/java/com/example/config/KafkaTopicConfig.java
+++ b/backend/report/src/main/java/com/example/config/KafkaTopicConfig.java
@@ -1,0 +1,19 @@
+package com.example.config;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.config.TopicBuilder;
+
+@ConfigurationProperties("spring.kafka")
+@RequiredArgsConstructor
+public class KafkaTopicConfig {
+  private final String topicName;
+
+  @Bean
+  public NewTopic topic() {
+    return TopicBuilder.name(topicName)
+      .build();
+  }
+}

--- a/backend/report/src/main/java/com/example/exception/ExceptionController.java
+++ b/backend/report/src/main/java/com/example/exception/ExceptionController.java
@@ -1,8 +1,6 @@
 package com.example.exception;
 
 
-import static com.example.exception.ErrorMessage.REQUEST_DATA_NOT_VALID;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -23,9 +21,10 @@ public class ExceptionController {
   public ExceptionResponse handleMethodArgumentNotValidException(
     MethodArgumentNotValidException e) {
     log.warn("handleMethodArgumentNotValidException: {}", e);
+    ExceptionMessage exceptionMessage = ExceptionMessage.findByMessage(e.getMessage());
     return ExceptionResponse.of(calculateCode(HttpStatus.BAD_REQUEST,
-        REQUEST_DATA_NOT_VALID.getCode()),
-      e.getClass().getName(), REQUEST_DATA_NOT_VALID.getMessage());
+        exceptionMessage.getCode()),
+      e.getClass().getName(), exceptionMessage.getMessage());
   }
 
   private String calculateCode(HttpStatus status, String code) {

--- a/backend/report/src/main/java/com/example/exception/ExceptionMessage.java
+++ b/backend/report/src/main/java/com/example/exception/ExceptionMessage.java
@@ -6,9 +6,18 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public enum ErrorMessage {
+public enum ExceptionMessage {
   REQUEST_DATA_NOT_VALID("001", "요청 데이터가 올바르지 않습니다.");
 
   private final String code;
   private final String message;
+
+  public static ExceptionMessage findByMessage(String message) {
+    for (ExceptionMessage e : values()) {
+      if (e.getMessage().equals(message)) {
+        return e;
+      }
+    }
+    return null;
+  }
 }

--- a/backend/report/src/main/java/com/example/repository/ReportCountRepository.java
+++ b/backend/report/src/main/java/com/example/repository/ReportCountRepository.java
@@ -13,13 +13,13 @@ public class ReportCountRepository {
   private static final int DURATION_IN_HOUR = 12;
   private final RedisTemplate redisTemplate;
 
-  public void increaseReportCount(String topicId, String reportedUser) {
+  public long increaseReportCount(String topicId, String reportedUser) {
     String key = topicId + "::" + reportedUser;
     ValueOperations valueOperations = redisTemplate.opsForValue();
     if (valueOperations.get(key) == null) {
       valueOperations.set(key, "1", Duration.ofHours(DURATION_IN_HOUR));
-      return;
+      return 1;
     }
-    valueOperations.increment(key);
+    return valueOperations.increment(key);
   }
 }

--- a/backend/report/src/main/java/com/example/service/ReportEvent.java
+++ b/backend/report/src/main/java/com/example/service/ReportEvent.java
@@ -1,0 +1,22 @@
+package com.example.service;
+
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+class ReportEvent {
+
+  @NotEmpty
+  private String topicId;
+  @NotEmpty
+  private String reportedUser;
+
+  public ReportEvent(String topicId, String reportedUser) {
+    this.topicId = topicId;
+    this.reportedUser = reportedUser;
+  }
+}

--- a/backend/report/src/main/java/com/example/service/ReportProducer.java
+++ b/backend/report/src/main/java/com/example/service/ReportProducer.java
@@ -1,0 +1,25 @@
+package com.example.service;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportProducer {
+
+  private final NewTopic topic;
+  private final KafkaTemplate<String, ReportEvent> kafkaTemplate;
+
+  public void send(String topicId, String reportedUser) {
+    Message<ReportEvent> message = MessageBuilder
+      .withPayload(new ReportEvent(topicId, reportedUser))
+      .setHeader(KafkaHeaders.TOPIC, topic.name())
+      .build();
+    kafkaTemplate.send(message);
+  }
+}

--- a/backend/report/src/main/resources/application.yml
+++ b/backend/report/src/main/resources/application.yml
@@ -26,3 +26,16 @@ spring:
       schema-locations:
         - classpath:sql/report_schema.sql
       mode: always
+  kafka:
+    producer:
+      bootstrap-servers: ${KAFKA_SERVER}
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring:
+          json:
+            type:
+              mapping: reportEvent:com.example.service.ReportEvent
+    topicName: report_topics
+server:
+  port: 8081


### PR DESCRIPTION
* 앞에 레디스 클러스터 구현 pr이 merge가 되지 않아 현재 pr에 올라와있는 상태입니다.
* 신고 서버 예외 처리 클래스, 로직을 수정하였습니다.
---
* 신고 횟수가 10번 이상이 될 경우 채팅서버로 메시지를 발행하고 채팅서버에서 받아서 처리하는 구조입니다.